### PR TITLE
Add support for value mappings

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -5,7 +5,7 @@ import { FieldSelectEditor } from './FieldSelectEditor';
 
 export const plugin = new PanelPlugin<TreemapOptions>(TreemapPanel)
   .useFieldConfig({
-    standardOptions: [FieldConfigProperty.Decimals, FieldConfigProperty.Unit],
+    standardOptions: [FieldConfigProperty.Decimals, FieldConfigProperty.Unit, FieldConfigProperty.Mappings],
   })
   .setPanelOptions(builder => {
     return builder

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,7 +3,7 @@
   "name": "Treemap",
   "id": "marcusolsson-treemap-panel",
   "info": {
-    "description": "",
+    "description": "Treemap panel for Grafana.",
     "author": {
       "name": "Marcus Olsson",
       "url": "https://marcus.se.net"


### PR DESCRIPTION
This PR adds support for value mappings. Unfortunately, this feature is affected by [a bug](https://github.com/grafana/grafana/issues/25070) in Grafana where mappings for string fields aren't persisted. 

This PR also adds improved error messages.

Fixes #2 