### PR TITLE
Enable adaptive text

### DIFF
--- a/src/AdaptiveText.tsx
+++ b/src/AdaptiveText.tsx
@@ -1,0 +1,47 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { useTheme } from '@grafana/ui';
+
+interface Props {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+}
+
+export const AdaptiveText = ({ x, y, width, height, text }: Props) => {
+  const theme = useTheme();
+  const [scale, setScale] = useState(1);
+
+  const ref = useRef<SVGTextElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      setScale(calculateScale(ref.current, width, height));
+    }
+  }, [ref, width, height]);
+
+  const originX = x - scale * x;
+  const originY = y - scale * y;
+
+  return (
+    <text
+      ref={ref}
+      fontFamily={theme.typography.fontFamily.sansSerif}
+      fontWeight={theme.typography.weight.regular}
+      x={x}
+      y={y + 12}
+      fill={theme.colors.panelBg}
+      transform={`matrix(${scale}, 0, 0, ${scale}, ${originX}, ${originY})`}
+    >
+      {text}
+    </text>
+  );
+};
+
+const calculateScale = (el: SVGTextElement, width: number, height: number) => {
+  const bb = el.getBBox();
+  const widthTransform = width / bb.width;
+  const heightTransform = height / bb.height;
+  return widthTransform < heightTransform ? widthTransform : heightTransform;
+};

--- a/src/TreemapPanel.tsx
+++ b/src/TreemapPanel.tsx
@@ -7,6 +7,7 @@ import { css } from 'emotion';
 import { PanelProps, MappingType, ValueMap, RangeMap, ValueMapping, Field, ArrayVector } from '@grafana/data';
 import { useTheme, Badge, ContextMenu, MenuItemsGroup, MenuItem, InfoBox } from '@grafana/ui';
 
+import { AdaptiveText } from './AdaptiveText';
 import { TreemapOptions } from 'types';
 
 // Tippy
@@ -213,17 +214,13 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
                       height={innerHeight}
                       fill={node.colorByField!.display!(colorValue).color!}
                     />
-                    {textFitsInRect ? (
-                      <text
-                        x={d.x0 + margin.left}
-                        y={d.y0 + margin.top}
-                        fontSize="12px"
-                        fontWeight="500"
-                        fill={theme.colors.panelBg}
-                      >
-                        {node.name}
-                      </text>
-                    ) : null}
+                    <AdaptiveText
+                      x={d.x0 + 5}
+                      y={d.y0 + 5}
+                      text={node.name}
+                      width={innerWidth - 10}
+                      height={innerHeight - 10}
+                    />
                   </g>
                 </Tippy>
               );


### PR DESCRIPTION
Experiments with adaptive text. This is currently very costly to render, so resizing the panel can get choppy for a large number of values.

<img width="1449" alt="CleanShot 2021-02-12 at 10 26 13@2x" src="https://user-images.githubusercontent.com/8396880/107750774-c665bc00-6d1c-11eb-8a9a-50d03f8a96c3.png">
