### PR TITLE
Testing: Coalesce multiple test coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ ci/
 .eslintcache
 
 monocart-report/
+
+coverage-merged/

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -33,6 +33,7 @@
     "monocart",
     "olsson",
     "polystat",
+    "popperjs",
     "squarify",
     "tippyjs",
     "treemap",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - ./playwright-report:/app/playwright-report
       - ./coverage:/app/coverage
       - ./package.json:/app/package.json
+      - ./scripts:/app/scripts
     profiles: [playwright]
     depends_on:
       - grafana
@@ -42,6 +43,7 @@ services:
       - ./playwright:/app/playwright
       - ./playwright-report:/app/playwright-report
       - ./package.json:/app/package.json
+      - ./scripts:/app/scripts
     profiles: [playwright-update-screenshots]
     depends_on:
       - grafana

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
       - ./playwright:/app/playwright
       - ./playwright-report:/app/playwright-report
       - ./coverage:/app/coverage
-      - ./package.json:/app/package.json
       - ./scripts:/app/scripts
     profiles: [playwright]
     depends_on:
@@ -42,7 +41,6 @@ services:
       - ./test-results:/app/test-results
       - ./playwright:/app/playwright
       - ./playwright-report:/app/playwright-report
-      - ./package.json:/app/package.json
       - ./scripts:/app/scripts
     profiles: [playwright-update-screenshots]
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - ./playwright:/app/playwright
       - ./playwright-report:/app/playwright-report
       - ./coverage:/app/coverage
+      - ./package.json:/app/package.json
     profiles: [playwright]
     depends_on:
       - grafana
@@ -40,6 +41,7 @@ services:
       - ./test-results:/app/test-results
       - ./playwright:/app/playwright
       - ./playwright-report:/app/playwright-report
+      - ./package.json:/app/package.json
     profiles: [playwright-update-screenshots]
     depends_on:
       - grafana

--- a/e2e/Dockerfile.playwright
+++ b/e2e/Dockerfile.playwright
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/playwright:v1.54.1-noble
+FROM mcr.microsoft.com/playwright:v1.55.0-noble
 
 WORKDIR /app
 
 # required by the e2e test code
-RUN npm install "@playwright/test@^1.54.1" "dotenv@^16.3.1" "@grafana/plugin-e2e" "monocart-reporter"
+RUN npm install "@playwright/test@1.55.0" "dotenv@^16.3.1" "@grafana/plugin-e2e" "monocart-reporter"
 
 CMD ["npx", "playwright", "test", "-c", "e2e/playwright.config.ts"]
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -41,8 +41,8 @@ export default defineConfig<PluginOptions>({
         ],
         all: './src',
         baseDir: './',
-        sourceFilter: createInstrumentedSourceFilter(),
-        sourcePath: createSourcePath()
+        sourceFilter: createInstrumentedSourceFilter({ packageName: 'marcusolsson-treemap-panel' }),
+        sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' })
       }
     }]
   ],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,7 +4,7 @@ import { dirname } from 'node:path';
 
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 const { name: PACKAGE_NAME } = require('../package.json');
-const { createSourcePath, createInstrumentedSourceFilter } = require('../scripts/utils/coverage');
+const { createSourcePath, createSourceFilterConfig } = require('../scripts/utils/coverage');
 
 /**
  * Read environment variables from file.
@@ -41,7 +41,11 @@ export default defineConfig<PluginOptions>({
         ],
         all: './src',
         baseDir: './',
-        sourceFilter: createInstrumentedSourceFilter({ packageName: 'marcusolsson-treemap-panel' }),
+        sourceFilter: createSourceFilterConfig({ 
+          packageName: 'marcusolsson-treemap-panel',
+          includeTypescriptOnly: true,
+          excludeTypes: true 
+        }),
         sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' })
       }
     }]

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,6 +4,7 @@ import { dirname } from 'node:path';
 
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 const { name: PACKAGE_NAME } = require('../package.json');
+const { createSourcePath, createInstrumentedSourceFilter } = require('../scripts/utils/coverage');
 
 /**
  * Read environment variables from file.
@@ -40,47 +41,8 @@ export default defineConfig<PluginOptions>({
         ],
         all: './src',
         baseDir: './',
-        sourceFilter: (sourcePath) => {
-          // Include TypeScript files that are either:
-          // 1. In OUR project's src/ directories (not external ones)
-          // 2. Root-level files in our plugin
-          const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
-          const isOurSrcDirectory = sourcePath.startsWith('src/') ||
-            (sourcePath.includes(PACKAGE_NAME) && sourcePath.includes('/src/'));
-          const isRootPluginFile = sourcePath.includes(PACKAGE_NAME) &&
-            !sourcePath.includes('node_modules/') &&
-            !sourcePath.includes('webpack/') &&
-            !sourcePath.includes('external ') &&
-            !sourcePath.includes('/src/') &&  // Root files don't have /src/ in path
-            !sourcePath.includes('grafana-plugin-support/');
-
-          return isTypeScriptFile &&
-            (isOurSrcDirectory || isRootPluginFile) &&
-            !sourcePath.includes('.test.') &&
-            !sourcePath.includes('.spec.') &&
-            !sourcePath.includes('__tests__') &&
-            !sourcePath.includes('__mocks__') &&
-            !sourcePath.endsWith('.d.ts');
-        },
-
-        // NOTE: We must normalize paths to start with 'src/' instead of the
-        //       package name for interoperability with Jest test reports.
-        sourcePath: (filePath) => {
-          if (filePath.includes(PACKAGE_NAME) && !filePath.includes('/src/')) {
-            const fileName = filePath.split('/').pop();
-            return `src/${fileName}`;
-          }
-
-          if (filePath.includes(`${PACKAGE_NAME}/grafana-plugin-support/`)) {
-            return filePath.replace(`${PACKAGE_NAME}/`, 'src/');
-          }
-
-          if (filePath.includes(`${PACKAGE_NAME}/src/`)) {
-            return filePath.replace(`${PACKAGE_NAME}/`, '');
-          }
-
-          return filePath;
-        }
+        sourceFilter: createInstrumentedSourceFilter(),
+        sourcePath: createSourcePath()
       }
     }]
   ],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig<PluginOptions>({
   reporter: [
     ['html', { host: '0.0.0.0', port: 9323 }],
     ['monocart-reporter', {
-      name: 'Treemap Panel E2E Coverage',
+      name: 'Treemap panel E2E tests',
       outputDir: './playwright-report/monocart',
       coverage: {
         outputDir: 'coverage/e2e/',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -29,8 +29,15 @@ export default defineConfig<PluginOptions>({
       name: 'Treemap Panel E2E Coverage',
       outputDir: './playwright-report/monocart',
       coverage: {
-        reports: ['v8', 'html', 'json', 'text-summary', 'lcov'],
-        outputDir: './coverage/e2e/',
+        outputDir: 'coverage/e2e/',
+        reports: [
+          ['v8'],
+          ['html'],
+          ['json'],
+          ['text-summary'],
+          ['lcov'],
+          ['raw'],
+        ],
         all: './src',
         baseDir: './',
         sourceFilter: (sourcePath) => {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 import { dirname } from 'node:path';
 
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
-import { name as PACKAGE_NAME } from '../package.json';
+const { name: PACKAGE_NAME } = require('../package.json');
 
 /**
  * Read environment variables from file.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
 
-const { createSourcePath, createStaticSourceFilter } = require('./scripts/utils/coverage');
+const { createSourcePath, createSourceFilterConfig } = require('./scripts/utils/coverage');
 
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
@@ -36,7 +36,11 @@ module.exports = {
         ['raw'],
       ],
       all: './src',
-      sourceFilter: createStaticSourceFilter({ excludeTypes: true, packageName: 'marcusolsson-treemap-panel' }),
+      sourceFilter: createSourceFilterConfig({ 
+        excludeTypes: true, 
+        packageName: 'marcusolsson-treemap-panel',
+        includeTypescriptOnly: false
+      }),
       sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' })
     }]
   ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,8 +36,8 @@ module.exports = {
         ['raw'],
       ],
       all: './src',
-      sourceFilter: createStaticSourceFilter({ excludeTypes: true }),
-      sourcePath: createSourcePath()
+      sourceFilter: createStaticSourceFilter({ excludeTypes: true, packageName: 'marcusolsson-treemap-panel' }),
+      sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' })
     }]
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   reporters: [
     'default',
     ['jest-monocart-coverage', {
-      name: 'Treemap Panel Jest Unit Tests Coverage',
+      name: 'Coverage Report - Treemap panel Jest unit tests',
       outputDir: './coverage/unit',
       reports: [
         ['v8'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC';
 
+const { createSourcePath, createStaticSourceFilter } = require('./scripts/utils/coverage');
+
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),
@@ -22,7 +24,7 @@ module.exports = {
   
   // Custom reporters
   reporters: [
-    'default', // Keep default Jest console output
+    'default',
     ['jest-monocart-coverage', {
       name: 'Treemap Panel Jest Unit Tests Coverage',
       outputDir: './coverage/unit',
@@ -34,29 +36,8 @@ module.exports = {
         ['raw'],
       ],
       all: './src',
-      sourceFilter: (sourcePath) => {
-        return sourcePath.startsWith('src/') && 
-               (sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx') || 
-                sourcePath.endsWith('.js') || sourcePath.endsWith('.jsx')) &&
-               !sourcePath.includes('.test.') &&
-               !sourcePath.includes('.spec.') &&
-               !sourcePath.includes('__tests__') &&
-               !sourcePath.includes('__mocks__') &&
-               !sourcePath.endsWith('.d.ts') &&
-               !sourcePath.endsWith('/types.ts'); // Exclude type definition files
-      },
-      sourcePath: (filePath) => {
-        if (!filePath.startsWith('src/') && !filePath.startsWith('/')) {
-          return `src/${filePath}`;
-        }
-        
-        if (filePath.startsWith('/')) {
-          const cleanPath = filePath.substring(1);
-          return cleanPath.startsWith('src/') ? cleanPath : `src/${cleanPath}`;
-        }
-        
-        return filePath;
-      }
+      sourceFilter: createStaticSourceFilter({ excludeTypes: true }),
+      sourcePath: createSourcePath()
     }]
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,17 +25,15 @@ module.exports = {
     'default', // Keep default Jest console output
     ['jest-monocart-coverage', {
       name: 'Treemap Panel Jest Unit Tests Coverage',
-      reports: [
-        'v8',
-        'console-summary',
-        'lcov'
-      ],
       outputDir: './coverage/unit',
-      
-      // Include all files, even untested ones (show 0% coverage)
+      reports: [
+        ['v8'],
+        ['console-summary'],
+        ['lcov'],
+        ['json'],
+        ['raw'],
+      ],
       all: './src',
-      
-      // Filter to only include our TypeScript/JavaScript files
       sourceFilter: (sourcePath) => {
         return sourcePath.startsWith('src/') && 
                (sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx') || 
@@ -47,15 +45,11 @@ module.exports = {
                !sourcePath.endsWith('.d.ts') &&
                !sourcePath.endsWith('/types.ts'); // Exclude type definition files
       },
-      
-      // Normalize paths to ensure consistency (should already start with 'src/')
       sourcePath: (filePath) => {
-        // Ensure all paths start with 'src/' for consistency with E2E reports
         if (!filePath.startsWith('src/') && !filePath.startsWith('/')) {
           return `src/${filePath}`;
         }
         
-        // Remove any leading slashes and ensure src/ prefix
         if (filePath.startsWith('/')) {
           const cleanPath = filePath.substring(1);
           return cleanPath.startsWith('src/') ? cleanPath : `src/${cleanPath}`;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "e2e": "docker compose --profile playwright up --abort-on-container-exit",
     "e2e:update-screenshots": "docker compose --profile playwright-update-screenshots up --abort-on-container-exit",
     "server": "docker compose up --build",
-    "sign": "npx --yes @grafana/sign-plugin@latest"
+    "sign": "npx --yes @grafana/sign-plugin@latest",
+    "coverage": "yarn coverage:clean && yarn e2e && yarn test:ci && yarn coverage:merge-reports",
+    "coverage:clean": "rm -rf coverage && rm -rf coverage-merged",
+    "coverage:merge-reports": "node scripts/merge-coverage.js"
   },
   "homepage": "https://grafana.com/plugins/marcusolsson-treemap-panel",
   "bugs": "https://github.com/grafana/grafana-treemap-panel/issues",
@@ -86,6 +89,7 @@
     "@grafana/runtime": "^11.5.3",
     "@grafana/schema": "^11.5.3",
     "@grafana/ui": "^11.5.3",
+    "monocart-coverage-reports": "^2.12.6",
     "rb-tippyjs-react": "^4.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@grafana/eslint-config": "^8.0.0",
     "@grafana/plugin-e2e": "^2.0.2",
     "@grafana/tsconfig": "^2.0.0",
-    "@playwright/test": "^1.54.1",
+    "@playwright/test": "1.55.0",
     "@stylistic/eslint-plugin-ts": "^2.9.0",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { CoverageReport } = require('monocart-coverage-reports');
-const { name: PACKAGE_NAME } = require('../package.json');
+const { createSourcePath, createInstrumentedSourceFilter } = require('./utils/coverage');
 
 const INPUT_DIRS = [
   './coverage/unit/raw',
@@ -22,33 +22,8 @@ async function mergeCoverageReports() {
       ['lcov'],
     ],
 
-    sourceFilter: (sourcePath) => {
-      return sourcePath.startsWith('src/') &&
-             !sourcePath.includes('node_modules') &&
-             !sourcePath.includes('webpack') &&
-             !sourcePath.includes('external amd') &&
-             !sourcePath.includes('rb-tippyjs-react') &&
-             !sourcePath.includes('tippy.js') &&
-             !sourcePath.includes('semver') &&
-             !sourcePath.includes('@popperjs');
-    },
-
-    sourcePath: (filePath, info) => {
-      if (filePath.includes(`${PACKAGE_NAME}/`) && !filePath.includes('/src/')) {
-        const fileName = filePath.replace(`${PACKAGE_NAME}/`, '');
-        return fileName.startsWith('src/') ? fileName : `src/${fileName}`;
-      }
-      
-      if (filePath.includes(`${PACKAGE_NAME}/`) && filePath.includes('/src/')) {
-        return filePath.replace(`${PACKAGE_NAME}/`, 'src/');
-      }
-      
-      if (!filePath.startsWith('src/') && !filePath.includes('node_modules') && !filePath.includes('webpack') && !filePath.includes('external')) {
-        return `src/${filePath}`;
-      }
-      
-      return filePath;
-    },
+    sourceFilter: createInstrumentedSourceFilter(),
+    sourcePath: createSourcePath(),
     // logging: 'debug'
   });
 

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,19 +1,28 @@
 #!/usr/bin/env node
 
 const { CoverageReport } = require('monocart-coverage-reports');
+const { glob } = require('glob');
 const { createSourcePath, createInstrumentedSourceFilter } = require('./utils/coverage');
 
-const INPUT_DIRS = [
-  './coverage/unit/raw',
-  './coverage/e2e/raw'
-];
+const RAW_COVERAGE_PATTERN = 'coverage/*/raw';
 
 // SEE: https://github.com/cenfun/monocart-coverage-reports#manual-merging
 async function mergeCoverageReports() {
+  const inputDirs = await glob(RAW_COVERAGE_PATTERN, {
+    cwd: process.cwd(),
+    onlyDirectories: true
+  });
+
+  if (inputDirs.length === 0) {
+    console.warn(
+      `⚠️  No raw coverage found in: ${RAW_COVERAGE_PATTERN} ... make sure your coverage reports have been generated first.`
+    );
+    process.exit(1);
+  }
 
   const coverageReport = new CoverageReport({
-    name: `Coverage Report - Merged (${INPUT_DIRS.length}) coverage reports`,
-    inputDir: INPUT_DIRS,
+    name: `Coverage Report - Merged (${inputDirs.length}) coverage reports`,
+    inputDir: inputDirs,
     outputDir: './coverage-merged',
     reports: [
       ['v8'],
@@ -33,4 +42,3 @@ async function mergeCoverageReports() {
 if (require.main === module) {
   mergeCoverageReports().catch(console.error);
 }
-

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { CoverageReport } = require('monocart-coverage-reports');
+const { name: PACKAGE_NAME } = require('../package.json');
 
 const INPUT_DIRS = [
   './coverage/unit/raw',
@@ -17,9 +18,35 @@ async function mergeCoverageReports() {
     reports: [
       ['v8'],
       ['console-details'],
+      ['json'],
+      ['lcov'],
     ],
+
+    sourceFilter: (sourcePath) => {
+      return sourcePath.startsWith('src/') &&
+             !sourcePath.includes('node_modules') &&
+             !sourcePath.includes('webpack') &&
+             !sourcePath.includes('external amd') &&
+             !sourcePath.includes('rb-tippyjs-react') &&
+             !sourcePath.includes('tippy.js') &&
+             !sourcePath.includes('semver') &&
+             !sourcePath.includes('@popperjs');
+    },
+
     sourcePath: (filePath, info) => {
-      console.info('filePath', filePath);
+      if (filePath.includes(`${PACKAGE_NAME}/`) && !filePath.includes('/src/')) {
+        const fileName = filePath.replace(`${PACKAGE_NAME}/`, '');
+        return fileName.startsWith('src/') ? fileName : `src/${fileName}`;
+      }
+      
+      if (filePath.includes(`${PACKAGE_NAME}/`) && filePath.includes('/src/')) {
+        return filePath.replace(`${PACKAGE_NAME}/`, 'src/');
+      }
+      
+      if (!filePath.startsWith('src/') && !filePath.includes('node_modules') && !filePath.includes('webpack') && !filePath.includes('external')) {
+        return `src/${filePath}`;
+      }
+      
       return filePath;
     },
     // logging: 'debug'

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -10,9 +10,9 @@ const INPUT_DIRS = [
 
 // SEE: https://github.com/cenfun/monocart-coverage-reports#manual-merging
 async function mergeCoverageReports() {
-  
+
   const coverageReport = new CoverageReport({
-    name: 'Merged Coverage Report',
+    name: `Coverage Report - Merged (${INPUT_DIRS.length}) coverage reports`,
     inputDir: INPUT_DIRS,
     outputDir: './coverage-merged',
     reports: [
@@ -33,3 +33,4 @@ async function mergeCoverageReports() {
 if (require.main === module) {
   mergeCoverageReports().catch(console.error);
 }
+

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { CoverageReport } = require('monocart-coverage-reports');
+
+const INPUT_DIRS = [
+  './coverage/unit/raw',
+  './coverage/e2e/raw'
+];
+
+// SEE: https://github.com/cenfun/monocart-coverage-reports#manual-merging
+async function mergeCoverageReports() {
+  
+  const coverageReport = new CoverageReport({
+    name: 'Merged Coverage Report',
+    inputDir: INPUT_DIRS,
+    outputDir: './coverage-merged',
+    reports: [
+      ['v8'],
+      ['console-details'],
+    ],
+    sourcePath: (filePath, info) => {
+      console.info('filePath', filePath);
+      return filePath;
+    },
+    // logging: 'debug'
+  });
+
+  await coverageReport.generate();
+}
+
+if (require.main === module) {
+  mergeCoverageReports().catch(console.error);
+}

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -31,8 +31,8 @@ async function mergeCoverageReports() {
       ['lcov'],
     ],
 
-    sourceFilter: createInstrumentedSourceFilter(),
-    sourcePath: createSourcePath(),
+    sourceFilter: createInstrumentedSourceFilter({ packageName: 'marcusolsson-treemap-panel' }),
+    sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' }),
     // logging: 'debug'
   });
 

--- a/scripts/merge-coverage.js
+++ b/scripts/merge-coverage.js
@@ -2,7 +2,9 @@
 
 const { CoverageReport } = require('monocart-coverage-reports');
 const { glob } = require('glob');
-const { createSourcePath, createInstrumentedSourceFilter } = require('./utils/coverage');
+const fs = require('fs');
+const path = require('path');
+const { createSourcePath, createSourceFilterConfig } = require('./utils/coverage');
 
 const RAW_COVERAGE_PATTERN = 'coverage/*/raw';
 
@@ -27,16 +29,59 @@ async function mergeCoverageReports() {
     reports: [
       ['v8'],
       ['console-details'],
+      ['html'],
       ['json'],
       ['lcov'],
     ],
 
-    sourceFilter: createInstrumentedSourceFilter({ packageName: 'marcusolsson-treemap-panel' }),
+    sourceFilter: createSourceFilterConfig({ 
+      packageName: 'marcusolsson-treemap-panel',
+      includeTypescriptOnly: true,
+      excludeTypes: true
+    }),
     sourcePath: createSourcePath({ packageName: 'marcusolsson-treemap-panel' }),
     // logging: 'debug'
   });
 
   await coverageReport.generate();
+  
+  const mergedDir = path.join(process.cwd(), 'coverage-merged');
+  const targetDir = path.join(process.cwd(), 'coverage');
+  
+  const filesToCopy = [
+    'index.html',
+    'coverage-data.js',
+    'coverage-final.json'
+  ];
+  
+  try {
+    for (const file of filesToCopy) {
+      const sourcePath = path.join(mergedDir, file);
+      const targetPath = path.join(targetDir, file);
+      
+      if (fs.existsSync(sourcePath)) {
+        fs.copyFileSync(sourcePath, targetPath);
+      }
+    }
+    
+    const assetsSourceDir = path.join(mergedDir, 'assets');
+    const assetsTargetDir = path.join(targetDir, 'assets');
+    
+    if (fs.existsSync(assetsSourceDir)) {
+      if (!fs.existsSync(assetsTargetDir)) {
+        fs.mkdirSync(assetsTargetDir, { recursive: true });
+      }
+      
+      const assetFiles = fs.readdirSync(assetsSourceDir);
+      for (const assetFile of assetFiles) {
+        const assetSourcePath = path.join(assetsSourceDir, assetFile);
+        const assetTargetPath = path.join(assetsTargetDir, assetFile);
+        fs.copyFileSync(assetSourcePath, assetTargetPath);
+      }
+    }
+  } catch (error) {
+    console.warn(`⚠️ Could not copy merged report files:`, error.message);
+  }
 }
 
 if (require.main === module) {

--- a/scripts/utils/coverage.js
+++ b/scripts/utils/coverage.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @typedef {Object} FilterOptions
+ * @typedef {Object} CoverageFilterOptions
  * @property {boolean} [includeTypescriptOnly=false] - Whether to include only TypeScript files
  * @property {boolean} [excludeTypes=true] - Whether to exclude TypeScript declaration files
  * @property {string[]} [additionalExclusions=[]] - Additional patterns to exclude from coverage
@@ -12,8 +12,8 @@
  */
 
 /**
- * Creates a sourcePath function for normalizing file paths across different test runners.
- * This ensures all coverage reports use consistent src/ prefixed paths for both static and instrumented contexts.
+ * Creates a simplified sourcePath function for normalizing file paths across different test runners.
+ * Leverages essential path transformations while relying on monocart's built-in filtering.
  * 
  * @param {SourcePathOptions} [options={}] - Configuration options for path normalization
  * @returns {function(string): string} Function that normalizes file paths to src/ prefixed format
@@ -24,40 +24,24 @@ function createSourcePath(options = {}) {
   return (filePath) => {
     const { packageName } = sanitizedOptions;
 
-    if (filePath.includes(`${packageName}/`) && !filePath.includes('/src/')) {
-      const fileName = filePath.replace(`${packageName}/`, '');
-      return fileName.startsWith('src/') ? fileName : `src/${fileName}`;
+    if (filePath.includes(`${packageName}/`)) {
+      return filePath.replace(new RegExp(`.*${packageName}/`), 'src/');
     }
 
-    if (filePath.includes(`${packageName}/`) && filePath.includes('/src/')) {
-      return filePath.replace(`${packageName}/`, 'src/');
-    }
-
-    if (filePath.startsWith('/')) {
-      const cleanPath = filePath.substring(1);
-      return cleanPath.startsWith('src/') ? cleanPath : `src/${cleanPath}`;
-    }
-
-    if (!filePath.startsWith('src/') &&
-      !filePath.includes('node_modules') &&
-      !filePath.includes('webpack') &&
-      !filePath.includes('external')) {
-      return `src/${filePath}`;
-    }
-
-    return filePath;
+    return filePath.startsWith('src/') ? filePath : `src/${filePath}`;
   };
 }
 
 /**
- * Creates a sourceFilter function for static analysis contexts.
- * Example: when coverage is collected from Jest running on Node.js or merging coverage reports.
+ * Creates a monocart-compatible sourceFilter function with explicit filtering logic.
+ * This replaces pattern-based filtering with a function to avoid precedence issues.
+ * Works for both static analysis (Jest/Node.js) and browser-instrumented (Playwright/E2E) contexts.
  * 
- * @param {FilterOptions} [options={}] - Configuration options for filtering
- * @returns {function(string): boolean} Function that filters source files based on static analysis criteria
+ * @param {CoverageFilterOptions} [options={}] - Configuration options for filtering
+ * @returns {function(string): boolean} Function that filters source files based on explicit criteria
  */
-function createStaticSourceFilter(options = {}) {
-  const sanitizedOptions = sanitizeFilterOptions(options);
+function createSourceFilterConfig(options = {}) {
+  const sanitizedOptions = sanitizeCoverageFilterOptions(options);
   const { includeTypescriptOnly, excludeTypes, additionalExclusions } = sanitizedOptions;
 
   return (sourcePath) => {
@@ -65,86 +49,52 @@ function createStaticSourceFilter(options = {}) {
       return false;
     }
 
-    if (includeTypescriptOnly) {
-      const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
-      if (!isTypeScriptFile) {
-        return false;
-      }
-    } else {
-      const isSourceFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx') ||
-        sourcePath.endsWith('.js') || sourcePath.endsWith('.jsx');
-      if (!isSourceFile) {
-        return false;
-      }
+    const validExtensions = includeTypescriptOnly ? ['.ts', '.tsx'] : ['.ts', '.tsx', '.js', '.jsx'];
+    const hasValidExtension = validExtensions.some(ext => sourcePath.endsWith(ext));
+    if (!hasValidExtension) {
+      return false;
     }
 
-    const standardExclusions = [
-      'node_modules',
-      'webpack',
-      'external amd',
-      '.test.',
-      '.spec.',
-      '__tests__',
+    const testPatterns = [
+      '.spec.js',
+      '.spec.jsx',
+      '.spec.ts',
+      '.spec.tsx',
+      '.test.js',
+      '.test.jsx',
+      '.test.ts',
+      '.test.tsx',
       '__mocks__',
-      'rb-tippyjs-react',
-      'tippy.js',
-      'semver',
-      '@popperjs'
+      '__tests__',
     ];
+    if (testPatterns.some(pattern => sourcePath.includes(pattern))) {
+      return false;
+    }
 
     if (excludeTypes) {
-      standardExclusions.push('.d.ts');
-      if (sourcePath.endsWith('/types.ts')) {
+      if (sourcePath.endsWith('.d.ts') || sourcePath.endsWith('/types.ts')) {
         return false;
       }
     }
 
-    const allExclusions = [...standardExclusions, ...additionalExclusions];
-    for (const exclusion of allExclusions) {
-      if (sourcePath.includes(exclusion)) {
-        return false;
-      }
+    const excludePatterns = [
+      'node_modules',
+      '@popperjs',
+      'external',
+      'rb-tippyjs-react',
+      'semver',
+      'tippy.js',
+      'webpack',
+    ];
+    if (excludePatterns.some(pattern => sourcePath.includes(pattern))) {
+      return false;
+    }
+
+    if (additionalExclusions.some(exclusion => sourcePath.includes(exclusion))) {
+      return false;
     }
 
     return true;
-  };
-}
-
-/**
- * Creates a sourceFilter for browser-instrumented coverage contexts.
- * Example: when coverage is collected from bundled module.js files in Chrome via Playwright E2E.
- * 
- * @param {FilterOptions} [options={}] - Configuration options for filtering (requires packageName)
- * @returns {function(string): boolean} Function that filters source files based on browser instrumentation criteria
- */
-function createInstrumentedSourceFilter(options = {}) {
-  const sanitizedOptions = sanitizeFilterOptions(options, true);
-
-  return (sourcePath) => {
-    const { packageName } = sanitizedOptions;
-
-    // NOTE: For browser-instrumented coverage, we need to detect project files from
-    //       runtime-generated paths that may include package prefixes or webpack transforms.
-    // NOTE: Include TypeScript files that are either:
-    //       1. In OUR project's src/ directories (not external ones)  
-    //       2. Root-level files in our plugin (detected by package name)
-    const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
-    const isOurSrcDirectory = sourcePath.startsWith('src/') ||
-      (sourcePath.includes(packageName) && sourcePath.includes('/src/'));
-    const isRootPluginFile = sourcePath.includes(packageName) &&
-      !sourcePath.includes('node_modules/') &&
-      !sourcePath.includes('webpack/') &&
-      !sourcePath.includes('external ') &&
-      !sourcePath.includes('/src/') &&  // Root files don't have /src/ in path
-      !sourcePath.includes('grafana-plugin-support/');
-
-    return isTypeScriptFile &&
-      (isOurSrcDirectory || isRootPluginFile) &&
-      !sourcePath.includes('.test.') &&
-      !sourcePath.includes('.spec.') &&
-      !sourcePath.includes('__tests__') &&
-      !sourcePath.includes('__mocks__') &&
-      !sourcePath.endsWith('.d.ts');
   };
 }
 
@@ -166,18 +116,12 @@ function sanitizeSourcePathOptions(options = {}) {
 }
 
 /**
- * Sanitizes and validates filter options, providing defaults and checking for required fields.
+ * Sanitizes and validates coverage filter options, providing defaults and checking for required fields.
  * 
- * @param {FilterOptions} [options={}] - Configuration options to sanitize
- * @param {boolean} [requirePackageName=false] - Whether packageName is required
- * @returns {FilterOptions} Sanitized options with defaults applied
- * @throws {Error} When required packageName option is missing (if requirePackageName is true)
+ * @param {CoverageFilterOptions} [options={}] - Configuration options to sanitize
+ * @returns {CoverageFilterOptions} Sanitized options with defaults applied
  */
-function sanitizeFilterOptions(options = {}, requirePackageName = false) {
-  if (requirePackageName && !options?.packageName) {
-    throw new Error('Missing mandatory option: `packageName` ...')
-  }
-  
+function sanitizeCoverageFilterOptions(options = {}) {
   return {
     includeTypescriptOnly: options.includeTypescriptOnly ?? false,
     excludeTypes: options.excludeTypes ?? true,
@@ -188,6 +132,5 @@ function sanitizeFilterOptions(options = {}, requirePackageName = false) {
 
 module.exports = {
   createSourcePath,
-  createStaticSourceFilter,
-  createInstrumentedSourceFilter
+  createSourceFilterConfig
 };

--- a/scripts/utils/coverage.js
+++ b/scripts/utils/coverage.js
@@ -1,18 +1,36 @@
-const { name: PACKAGE_NAME } = require('../../package.json');
+/**
+ * @typedef {Object} SourcePathOptions
+ * @property {string} packageName - The package name used for path normalization
+ */
+
+/**
+ * @typedef {Object} FilterOptions
+ * @property {boolean} [includeTypescriptOnly=false] - Whether to include only TypeScript files
+ * @property {boolean} [excludeTypes=true] - Whether to exclude TypeScript declaration files
+ * @property {string[]} [additionalExclusions=[]] - Additional patterns to exclude from coverage
+ * @property {string} [packageName] - The package name used for path filtration
+ */
 
 /**
  * Creates a sourcePath function for normalizing file paths across different test runners.
  * This ensures all coverage reports use consistent src/ prefixed paths for both static and instrumented contexts.
+ * 
+ * @param {SourcePathOptions} [options={}] - Configuration options for path normalization
+ * @returns {function(string): string} Function that normalizes file paths to src/ prefixed format
  */
-function createSourcePath() {
+function createSourcePath(options = {}) {
+  const sanitizedOptions = sanitizeSourcePathOptions(options);
+
   return (filePath) => {
-    if (filePath.includes(`${PACKAGE_NAME}/`) && !filePath.includes('/src/')) {
-      const fileName = filePath.replace(`${PACKAGE_NAME}/`, '');
+    const { packageName } = sanitizedOptions;
+
+    if (filePath.includes(`${packageName}/`) && !filePath.includes('/src/')) {
+      const fileName = filePath.replace(`${packageName}/`, '');
       return fileName.startsWith('src/') ? fileName : `src/${fileName}`;
     }
 
-    if (filePath.includes(`${PACKAGE_NAME}/`) && filePath.includes('/src/')) {
-      return filePath.replace(`${PACKAGE_NAME}/`, 'src/');
+    if (filePath.includes(`${packageName}/`) && filePath.includes('/src/')) {
+      return filePath.replace(`${packageName}/`, 'src/');
     }
 
     if (filePath.startsWith('/')) {
@@ -33,14 +51,14 @@ function createSourcePath() {
 
 /**
  * Creates a sourceFilter function for static analysis contexts.
- * Example: when is collected from Jest running on Node.js or merging coverage reports.
+ * Example: when coverage is collected from Jest running on Node.js or merging coverage reports.
+ * 
+ * @param {FilterOptions} [options={}] - Configuration options for filtering
+ * @returns {function(string): boolean} Function that filters source files based on static analysis criteria
  */
 function createStaticSourceFilter(options = {}) {
-  const {
-    includeTypescriptOnly = false,
-    excludeTypes = true,
-    additionalExclusions = []
-  } = options;
+  const sanitizedOptions = sanitizeFilterOptions(options);
+  const { includeTypescriptOnly, excludeTypes, additionalExclusions } = sanitizedOptions;
 
   return (sourcePath) => {
     if (!sourcePath.startsWith('src/')) {
@@ -95,9 +113,16 @@ function createStaticSourceFilter(options = {}) {
 /**
  * Creates a sourceFilter for browser-instrumented coverage contexts.
  * Example: when coverage is collected from bundled module.js files in Chrome via Playwright E2E.
+ * 
+ * @param {FilterOptions} [options={}] - Configuration options for filtering (requires packageName)
+ * @returns {function(string): boolean} Function that filters source files based on browser instrumentation criteria
  */
-function createInstrumentedSourceFilter() {
+function createInstrumentedSourceFilter(options = {}) {
+  const sanitizedOptions = sanitizeFilterOptions(options, true);
+
   return (sourcePath) => {
+    const { packageName } = sanitizedOptions;
+
     // NOTE: For browser-instrumented coverage, we need to detect project files from
     //       runtime-generated paths that may include package prefixes or webpack transforms.
     // NOTE: Include TypeScript files that are either:
@@ -105,8 +130,8 @@ function createInstrumentedSourceFilter() {
     //       2. Root-level files in our plugin (detected by package name)
     const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
     const isOurSrcDirectory = sourcePath.startsWith('src/') ||
-      (sourcePath.includes(PACKAGE_NAME) && sourcePath.includes('/src/'));
-    const isRootPluginFile = sourcePath.includes(PACKAGE_NAME) &&
+      (sourcePath.includes(packageName) && sourcePath.includes('/src/'));
+    const isRootPluginFile = sourcePath.includes(packageName) &&
       !sourcePath.includes('node_modules/') &&
       !sourcePath.includes('webpack/') &&
       !sourcePath.includes('external ') &&
@@ -123,9 +148,46 @@ function createInstrumentedSourceFilter() {
   };
 }
 
+/**
+ * Sanitizes and validates source path options, providing defaults and checking for required fields.
+ * 
+ * @param {SourcePathOptions} [options={}] - Configuration options to sanitize
+ * @returns {SourcePathOptions} Sanitized options with required fields validated
+ * @throws {Error} When required packageName option is missing
+ */
+function sanitizeSourcePathOptions(options = {}) {
+  if (!options?.packageName) {
+    throw new Error('Missing mandatory option: `packageName` ...')
+  }
+  
+  return {
+    packageName: options.packageName
+  };
+}
+
+/**
+ * Sanitizes and validates filter options, providing defaults and checking for required fields.
+ * 
+ * @param {FilterOptions} [options={}] - Configuration options to sanitize
+ * @param {boolean} [requirePackageName=false] - Whether packageName is required
+ * @returns {FilterOptions} Sanitized options with defaults applied
+ * @throws {Error} When required packageName option is missing (if requirePackageName is true)
+ */
+function sanitizeFilterOptions(options = {}, requirePackageName = false) {
+  if (requirePackageName && !options?.packageName) {
+    throw new Error('Missing mandatory option: `packageName` ...')
+  }
+  
+  return {
+    includeTypescriptOnly: options.includeTypescriptOnly ?? false,
+    excludeTypes: options.excludeTypes ?? true,
+    additionalExclusions: options.additionalExclusions ?? [],
+    ...(options.packageName && { packageName: options.packageName })
+  };
+}
+
 module.exports = {
   createSourcePath,
   createStaticSourceFilter,
-  createInstrumentedSourceFilter,
-  PACKAGE_NAME
+  createInstrumentedSourceFilter
 };

--- a/scripts/utils/coverage.js
+++ b/scripts/utils/coverage.js
@@ -1,0 +1,131 @@
+const { name: PACKAGE_NAME } = require('../../package.json');
+
+/**
+ * Creates a sourcePath function for normalizing file paths across different test runners.
+ * This ensures all coverage reports use consistent src/ prefixed paths for both static and instrumented contexts.
+ */
+function createSourcePath() {
+  return (filePath) => {
+    if (filePath.includes(`${PACKAGE_NAME}/`) && !filePath.includes('/src/')) {
+      const fileName = filePath.replace(`${PACKAGE_NAME}/`, '');
+      return fileName.startsWith('src/') ? fileName : `src/${fileName}`;
+    }
+
+    if (filePath.includes(`${PACKAGE_NAME}/`) && filePath.includes('/src/')) {
+      return filePath.replace(`${PACKAGE_NAME}/`, 'src/');
+    }
+
+    if (filePath.startsWith('/')) {
+      const cleanPath = filePath.substring(1);
+      return cleanPath.startsWith('src/') ? cleanPath : `src/${cleanPath}`;
+    }
+
+    if (!filePath.startsWith('src/') &&
+      !filePath.includes('node_modules') &&
+      !filePath.includes('webpack') &&
+      !filePath.includes('external')) {
+      return `src/${filePath}`;
+    }
+
+    return filePath;
+  };
+}
+
+/**
+ * Creates a sourceFilter function for static analysis contexts.
+ * Example: when is collected from Jest running on Node.js or merging coverage reports.
+ */
+function createStaticSourceFilter(options = {}) {
+  const {
+    includeTypescriptOnly = false,
+    excludeTypes = true,
+    additionalExclusions = []
+  } = options;
+
+  return (sourcePath) => {
+    if (!sourcePath.startsWith('src/')) {
+      return false;
+    }
+
+    if (includeTypescriptOnly) {
+      const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
+      if (!isTypeScriptFile) {
+        return false;
+      }
+    } else {
+      const isSourceFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx') ||
+        sourcePath.endsWith('.js') || sourcePath.endsWith('.jsx');
+      if (!isSourceFile) {
+        return false;
+      }
+    }
+
+    const standardExclusions = [
+      'node_modules',
+      'webpack',
+      'external amd',
+      '.test.',
+      '.spec.',
+      '__tests__',
+      '__mocks__',
+      'rb-tippyjs-react',
+      'tippy.js',
+      'semver',
+      '@popperjs'
+    ];
+
+    if (excludeTypes) {
+      standardExclusions.push('.d.ts');
+      if (sourcePath.endsWith('/types.ts')) {
+        return false;
+      }
+    }
+
+    const allExclusions = [...standardExclusions, ...additionalExclusions];
+    for (const exclusion of allExclusions) {
+      if (sourcePath.includes(exclusion)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+}
+
+/**
+ * Creates a sourceFilter for browser-instrumented coverage contexts.
+ * Example: when coverage is collected from bundled module.js files in Chrome via Playwright E2E.
+ */
+function createInstrumentedSourceFilter() {
+  return (sourcePath) => {
+    // NOTE: For browser-instrumented coverage, we need to detect project files from
+    //       runtime-generated paths that may include package prefixes or webpack transforms.
+    // NOTE: Include TypeScript files that are either:
+    //       1. In OUR project's src/ directories (not external ones)  
+    //       2. Root-level files in our plugin (detected by package name)
+    const isTypeScriptFile = sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx');
+    const isOurSrcDirectory = sourcePath.startsWith('src/') ||
+      (sourcePath.includes(PACKAGE_NAME) && sourcePath.includes('/src/'));
+    const isRootPluginFile = sourcePath.includes(PACKAGE_NAME) &&
+      !sourcePath.includes('node_modules/') &&
+      !sourcePath.includes('webpack/') &&
+      !sourcePath.includes('external ') &&
+      !sourcePath.includes('/src/') &&  // Root files don't have /src/ in path
+      !sourcePath.includes('grafana-plugin-support/');
+
+    return isTypeScriptFile &&
+      (isOurSrcDirectory || isRootPluginFile) &&
+      !sourcePath.includes('.test.') &&
+      !sourcePath.includes('.spec.') &&
+      !sourcePath.includes('__tests__') &&
+      !sourcePath.includes('__mocks__') &&
+      !sourcePath.endsWith('.d.ts');
+  };
+}
+
+module.exports = {
+  createSourcePath,
+  createStaticSourceFilter,
+  createInstrumentedSourceFilter,
+  PACKAGE_NAME
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,12 +1197,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@^1.54.1":
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.54.1.tgz#a76333e5c2cba5f12f96a6da978bba3ab073c7e6"
-  integrity sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==
+"@playwright/test@1.55.0":
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.55.0.tgz#080fa6d9ee6d749ff523b1c18259572d0268b963"
+  integrity sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==
   dependencies:
-    playwright "1.54.1"
+    playwright "1.55.0"
 
 "@popperjs/core@2.11.8", "@popperjs/core@^2.9.0":
   version "2.11.8"
@@ -5266,7 +5266,7 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.1.3, istanbul-reports@^3.1.7:
+istanbul-reports@^3.1.3:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
   integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
@@ -6585,17 +6585,17 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.54.1:
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.54.1.tgz#d32edcce048c9d83ceac31e294a7b60ef586960b"
-  integrity sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==
+playwright-core@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.0.tgz#ec8a9f8ef118afb3e86e0f46f1393e3bea32adf4"
+  integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
 
-playwright@1.54.1:
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.54.1.tgz#128d66a8d5182b5330e6440be3a72ca313362788"
-  integrity sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==
+playwright@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.55.0.tgz#7aca7ac3ffd9e083a8ad8b2514d6f9ba401cc78b"
+  integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
   dependencies:
-    playwright-core "1.54.1"
+    playwright-core "1.55.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
🧪 🧑‍🔬 This change adds the configuration + scripts necessary to merge our existing Jest unit + Playwright E2E test coverage reports into a single coverage report for this plugin.
- 🎟️  https://github.com/grafana/grafana/issues/109629

<img width="1033" height="533" alt="Screenshot 2025-08-20 at 12 45 58 PM" src="https://github.com/user-attachments/assets/dcdb5143-61de-4c76-81b5-0a82351fd538" />

<img width="2438" height="759" alt="Screenshot 2025-08-20 at 10 32 47 AM" src="https://github.com/user-attachments/assets/944fd388-2ccb-4b03-b2c7-c978b1049ff3" />

<img width="2435" height="1353" alt="Screenshot 2025-08-20 at 10 32 20 AM" src="https://github.com/user-attachments/assets/d9b22a6b-bf30-4f27-9ffd-ce63a3b19195" />

### 🆕 Features of this implementation 

- Jest + Playwright test suites are configured to generate an additional `raw` target output
- Using `monocart-coverage-report` to simplify merging multiple reports _(🗑️ threw away my previous custom script)_
- Source file path normalization and filtration are now DRY'er and centralized


### 📋 **How to try these changes out for yourself locally:**

1. pull down this branch
2. `yarn install` and `yarn build`
3. `yarn coverage`
4. `open coverage/index.html`
    i. _(optional) `open coverage/e2e/index.html`_
    ii. _(optional) `open coverage/unit/index.html`_


### ⏩ What's next _(and not in scope for this change RN)_

- Persistence/transmission of test coverage metrics for this plugin