### PR TITLE
Fix treemap field detection (display-name aware) + remove deprecations

### DIFF
--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -32,9 +32,9 @@ export const Tooltip = ({ content, children }: Props) => {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   tooltip: css`
-    border-radius: ${theme.v1.border.radius.sm};
-    background-color: ${theme.v1.colors.bg2};
-    padding: ${theme.v1.spacing.sm};
-    box-shadow: 0px 0px 20px ${theme.v1.colors.dropdownShadow};
+    border-radius: ${theme.shape.radius.default};
+    background-color: ${theme.components.tooltip.background};
+    padding: ${theme.spacing(1)};
+    box-shadow: ${theme.shadows.z3};
   `,
 });

--- a/src/TreemapPanel.tsx
+++ b/src/TreemapPanel.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldType, PanelProps } from '@grafana/data';
+import { FieldType, PanelProps } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 import { getFormattedDisplayValue, PanelWizard } from './grafana-plugin-support/src';
 import React, { MouseEvent, useState } from 'react';
@@ -22,7 +22,7 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
   const [contextMenuGroups, setContextMenuGroups] = useState<MenuGroup[]>([]);
   const [showContextMenu, setShowContextMenu] = useState(false);
 
-  const theme = useTheme2().v1;
+  const theme = useTheme2();
 
   const frames: FrameView[] = buildFrameViews(data.series as any, options);
 
@@ -66,17 +66,17 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
           const node = d.data;
 
           if (node.frame) {
-            const textValue = node.frame.text!.values.get(node.frame.valueRowIndex!);
-            const sizeValue = node.frame.size!.values.get(node.frame.valueRowIndex!);
-            const colorValue = node.frame.color!.values.get(node.frame.valueRowIndex!);
+            const textValue = node.frame.text!.values[node.frame.valueRowIndex!];
+            const sizeValue = node.frame.size!.values[node.frame.valueRowIndex!];
+            const colorValue = node.frame.color!.values[node.frame.valueRowIndex!];
 
             const valueText = getFormattedDisplayValue(node.frame.size!.display!(sizeValue));
-            const fillColor = node.frame.color!.display!(colorValue).color ?? theme.colors.text;
+            const fillColor = node.frame.color!.display!(colorValue).color ?? theme.colors.text.primary;
 
             const labels =
               node.frame.valueRowIndex !== undefined
                 ? node.frame.labels
-                    ?.map((_: any) => _!.display!(_!.values.get(node.frame!.valueRowIndex!)))
+                    ?.map((_: any) => _!.display!(_!.values[node.frame!.valueRowIndex!]))
                     .map((_: any) => getFormattedDisplayValue(_))
                 : [];
 
@@ -128,7 +128,7 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
               label={node.name}
               value={''}
               labels={[]}
-              color={theme.colors.text}
+              color={theme.colors.text.primary}
               opacity={0.05}
             />
           );

--- a/src/TreemapPanel.tsx
+++ b/src/TreemapPanel.tsx
@@ -15,6 +15,42 @@ interface Props extends PanelProps<TreemapOptions> {}
 export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) => {
   const { tiling } = options;
 
+  const normalize = (value?: string) => (value ?? '').trim();
+
+  const fieldMatches = (field: Field, wanted?: string) => {
+    const wantedNormalized = normalize(wanted);
+    if (!wantedNormalized) {
+      return false;
+    }
+
+    const candidates = [
+      field.name,
+      field.config?.displayName,
+      field.config?.displayNameFromDS,
+      (field.state as any)?.displayName,
+    ]
+      .map(normalize)
+      .filter(Boolean);
+
+    return candidates.includes(wantedNormalized);
+  };
+
+  const findStringField = (frame: any, wanted?: string) => {
+    if (normalize(wanted)) {
+      return frame.fields.find((f: Field) => f.type === FieldType.string && fieldMatches(f, wanted));
+    }
+
+    return frame.fields.find((f: Field) => f.type === FieldType.string);
+  };
+
+  const findNumberField = (frame: any, wanted?: string) => {
+    if (normalize(wanted)) {
+      return frame.fields.find((f: Field) => f.type === FieldType.number && fieldMatches(f, wanted));
+    }
+
+    return frame.fields.find((f: Field) => f.type === FieldType.number);
+  };
+
   // State for context menu.
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
   const [contextMenuLabel, setContextMenuLabel] = useState<React.ReactNode | string>('');
@@ -25,24 +61,25 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
 
   const frames: FrameView[] = data.series
     .map((frame) => {
+      const text = findStringField(frame, options.textField);
+      const size = findNumberField(frame, options.sizeField);
+
+      // Color is optional unless explicitly configured. When not configured,
+      // default to using the same field as size.
+      const colorByFieldExplicit = normalize(options.colorByField).length > 0;
+      const color = colorByFieldExplicit ? findNumberField(frame, options.colorByField) : size ?? findNumberField(frame);
+
       return {
         name: frame.name,
         refId: frame.refId,
-        text: options.textField
-          ? frame.fields.find((f) => f.name === options.textField)
-          : frame.fields.find((f) => f.type === 'string'),
-        size: options.sizeField
-          ? frame.fields.find((f) => f.name === options.sizeField)
-          : frame.fields.find((f) => f.type === 'number'),
-        color: options.colorByField
-          ? frame.fields.find((f) => f.name === options.colorByField)
-          : frame.fields.find((f) => f.type === 'number'),
-        groupBy: frame.fields.find((f) => f.name === options.groupByField),
+        text,
+        size,
+        color,
+        groupBy: frame.fields.find((f: Field) => fieldMatches(f, options.groupByField)),
         labels:
           options.labelFields
-            ?.map((_) => frame.fields.find((f) => f.name === _))
-            .filter((_) => _)
-            .map((_) => _ as Field<any>) ?? [],
+            ?.map((name) => frame.fields.find((f: Field) => fieldMatches(f, name)))
+            .filter((f): f is Field<any> => Boolean(f)) ?? [],
       };
     })
     // Only use frames with proper fields.
@@ -93,7 +130,7 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
             const colorValue = node.frame.color!.values.get(node.frame.valueRowIndex!);
 
             const valueText = getFormattedDisplayValue(node.frame.size!.display!(sizeValue));
-            const fillColor = node.frame.color!.display!(colorValue).color!;
+            const fillColor = node.frame.color!.display!(colorValue).color ?? theme.colors.primary;
 
             const labels =
               node.frame.valueRowIndex !== undefined

--- a/src/TreemapPanel.tsx
+++ b/src/TreemapPanel.tsx
@@ -6,6 +6,7 @@ import { FrameView, TreemapOptions } from 'types';
 import { ContextMenu, MenuGroup } from './ContextMenu';
 import { buildHierarchy, buildLayout } from './treemap';
 import { TreemapTile } from './TreemapTile';
+import { buildFrameViews } from './frameSelection';
 
 interface Props extends PanelProps<TreemapOptions> {}
 
@@ -15,42 +16,6 @@ interface Props extends PanelProps<TreemapOptions> {}
 export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) => {
   const { tiling } = options;
 
-  const normalize = (value?: string) => (value ?? '').trim();
-
-  const fieldMatches = (field: Field, wanted?: string) => {
-    const wantedNormalized = normalize(wanted);
-    if (!wantedNormalized) {
-      return false;
-    }
-
-    const candidates = [
-      field.name,
-      field.config?.displayName,
-      field.config?.displayNameFromDS,
-      (field.state as any)?.displayName,
-    ]
-      .map(normalize)
-      .filter(Boolean);
-
-    return candidates.includes(wantedNormalized);
-  };
-
-  const findStringField = (frame: any, wanted?: string) => {
-    if (normalize(wanted)) {
-      return frame.fields.find((f: Field) => f.type === FieldType.string && fieldMatches(f, wanted));
-    }
-
-    return frame.fields.find((f: Field) => f.type === FieldType.string);
-  };
-
-  const findNumberField = (frame: any, wanted?: string) => {
-    if (normalize(wanted)) {
-      return frame.fields.find((f: Field) => f.type === FieldType.number && fieldMatches(f, wanted));
-    }
-
-    return frame.fields.find((f: Field) => f.type === FieldType.number);
-  };
-
   // State for context menu.
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
   const [contextMenuLabel, setContextMenuLabel] = useState<React.ReactNode | string>('');
@@ -59,31 +24,7 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
 
   const theme = useTheme2().v1;
 
-  const frames: FrameView[] = data.series
-    .map((frame) => {
-      const text = findStringField(frame, options.textField);
-      const size = findNumberField(frame, options.sizeField);
-
-      // Color is optional unless explicitly configured. When not configured,
-      // default to using the same field as size.
-      const colorByFieldExplicit = normalize(options.colorByField).length > 0;
-      const color = colorByFieldExplicit ? findNumberField(frame, options.colorByField) : size ?? findNumberField(frame);
-
-      return {
-        name: frame.name,
-        refId: frame.refId,
-        text,
-        size,
-        color,
-        groupBy: frame.fields.find((f: Field) => fieldMatches(f, options.groupByField)),
-        labels:
-          options.labelFields
-            ?.map((name) => frame.fields.find((f: Field) => fieldMatches(f, name)))
-            .filter((f): f is Field<any> => Boolean(f)) ?? [],
-      };
-    })
-    // Only use frames with proper fields.
-    .filter((frame) => frame.text && frame.size && frame.color);
+  const frames: FrameView[] = buildFrameViews(data.series as any, options);
 
   // Ensure that we have the data we need.
   if (frames.length === 0) {
@@ -130,7 +71,7 @@ export const TreemapPanel: React.FC<Props> = ({ options, data, width, height }) 
             const colorValue = node.frame.color!.values.get(node.frame.valueRowIndex!);
 
             const valueText = getFormattedDisplayValue(node.frame.size!.display!(sizeValue));
-            const fillColor = node.frame.color!.display!(colorValue).color ?? theme.colors.primary;
+            const fillColor = node.frame.color!.display!(colorValue).color ?? theme.colors.text;
 
             const labels =
               node.frame.valueRowIndex !== undefined

--- a/src/TreemapTile.tsx
+++ b/src/TreemapTile.tsx
@@ -18,7 +18,10 @@ interface Props {
 }
 
 export const TreemapTile = ({ x, y, width, height, label, value, labels, onClick, color, opacity }: Props) => {
-  const theme = useTheme2().v1;
+  const theme = useTheme2();
+  const tileRadius = Number.isFinite(Number.parseFloat(theme.shape.radius.default))
+    ? Number.parseFloat(theme.shape.radius.default)
+    : 0;
 
   const styles = {
     text: css`
@@ -46,7 +49,7 @@ export const TreemapTile = ({ x, y, width, height, label, value, labels, onClick
         <Badge
           key={key}
           className={css`
-            margin-right: ${theme.spacing.xs};
+            margin-right: ${theme.spacing(0.5)};
             &:last-child {
               margin-right: 0;
             }
@@ -70,8 +73,8 @@ export const TreemapTile = ({ x, y, width, height, label, value, labels, onClick
         <rect
           x={x}
           y={y}
-          rx={theme.border.radius.sm}
-          ry={theme.border.radius.sm}
+          rx={tileRadius}
+          ry={tileRadius}
           width={width}
           height={height}
           fill={color}
@@ -82,7 +85,7 @@ export const TreemapTile = ({ x, y, width, height, label, value, labels, onClick
             className={styles.text}
             x={x + margin.left}
             y={y + margin.top}
-            fill={opacity < 1 ? theme.colors.text : theme.colors.panelBg}
+            fill={opacity < 1 ? theme.colors.text.primary : theme.colors.background.primary}
           >
             {label}
           </text>

--- a/src/frameSelection.test.ts
+++ b/src/frameSelection.test.ts
@@ -1,0 +1,124 @@
+import { FieldType } from '@grafana/data';
+
+import { buildFrameViews, fieldMatches, normalize } from './frameSelection';
+import { TreemapOptions } from './types';
+
+const makeOptions = (overrides: Partial<TreemapOptions> = {}): TreemapOptions => {
+  return {
+    tiling: 'treemapSquarify',
+    textField: '',
+    sizeField: '',
+    colorByField: '',
+    labelFields: [],
+    groupByField: '',
+    ...overrides,
+  };
+};
+
+const makeField = (overrides: any) => {
+  return {
+    name: 'field',
+    type: FieldType.string,
+    values: { get: () => undefined },
+    config: {},
+    state: {},
+    ...overrides,
+  };
+};
+
+describe('frameSelection', () => {
+  test('normalize trims and handles undefined', () => {
+    expect(normalize(undefined)).toBe('');
+    expect(normalize('  a  ')).toBe('a');
+  });
+
+  test('fieldMatches checks name and display name variants', () => {
+    const f = makeField({
+      name: 'Value #A',
+      config: { displayName: 'debt_days', displayNameFromDS: 'debt_days_ds' },
+      state: { displayName: 'debt_days_state' },
+    });
+
+    expect(fieldMatches(f as any, 'Value #A')).toBe(true);
+    expect(fieldMatches(f as any, 'debt_days')).toBe(true);
+    expect(fieldMatches(f as any, 'debt_days_ds')).toBe(true);
+    expect(fieldMatches(f as any, 'debt_days_state')).toBe(true);
+
+    expect(fieldMatches(f as any, 'missing')).toBe(false);
+    expect(fieldMatches(f as any, '')).toBe(false);
+    expect(fieldMatches(f as any, '   ')).toBe(false);
+  });
+
+  test('buildFrameViews selects by displayName when field.name differs', () => {
+    const series = [
+      {
+        name: 'A',
+        refId: 'A',
+        fields: [
+          makeField({ name: 'project_key', type: FieldType.string, config: { displayName: 'project_key' } }),
+          makeField({ name: 'Value', type: FieldType.number, config: { displayName: 'debt_days' } }),
+        ],
+      },
+    ];
+
+    const options = makeOptions({
+      textField: 'project_key',
+      sizeField: 'debt_days',
+      colorByField: '',
+    });
+
+    const frames = buildFrameViews(series as any, options);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].text?.name).toBe('project_key');
+    expect(frames[0].size?.name).toBe('Value');
+    // colorByField unset => uses size
+    expect(frames[0].color?.name).toBe('Value');
+  });
+
+  test('buildFrameViews rejects frame when colorByField is explicitly set but not found', () => {
+    const series = [
+      {
+        name: 'A',
+        refId: 'A',
+        fields: [
+          makeField({ name: 'project_key', type: FieldType.string }),
+          makeField({ name: 'debt_days', type: FieldType.number }),
+        ],
+      },
+    ];
+
+    const options = makeOptions({
+      textField: 'project_key',
+      sizeField: 'debt_days',
+      colorByField: 'top10',
+    });
+
+    const frames = buildFrameViews(series as any, options);
+    expect(frames).toHaveLength(0);
+  });
+
+  test('buildFrameViews prefers exact name match when present', () => {
+    const series = [
+      {
+        name: 'A',
+        refId: 'A',
+        fields: [
+          makeField({ name: 'project_key', type: FieldType.string, config: { displayName: 'Project Key' } }),
+          makeField({ name: 'debt_days', type: FieldType.number, config: { displayName: 'Debt Days' } }),
+          makeField({ name: 'top10', type: FieldType.number, config: { displayName: 'Top 10%' } }),
+        ],
+      },
+    ];
+
+    const options = makeOptions({
+      textField: 'project_key',
+      sizeField: 'debt_days',
+      colorByField: 'top10',
+    });
+
+    const frames = buildFrameViews(series as any, options);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].size?.name).toBe('debt_days');
+    expect(frames[0].color?.name).toBe('top10');
+  });
+});

--- a/src/frameSelection.ts
+++ b/src/frameSelection.ts
@@ -1,0 +1,70 @@
+import { Field, FieldType } from '@grafana/data';
+
+import { FrameView, TreemapOptions } from './types';
+
+export const normalize = (value?: string) => (value ?? '').trim();
+
+export const fieldMatches = (field: Field, wanted?: string): boolean => {
+  const wantedNormalized = normalize(wanted);
+  if (!wantedNormalized) {
+    return false;
+  }
+
+  const candidates = [
+    field.name,
+    field.config?.displayName,
+    field.config?.displayNameFromDS,
+    (field.state as any)?.displayName,
+  ]
+    .map(normalize)
+    .filter(Boolean);
+
+  return candidates.includes(wantedNormalized);
+};
+
+export const findFieldByTypeAndName = <T = unknown>(
+  frame: { fields: Array<Field> },
+  type: FieldType,
+  wanted?: string
+): Field<T> | undefined => {
+  if (normalize(wanted)) {
+    return frame.fields.find((f) => f.type === type && fieldMatches(f, wanted)) as Field<T> | undefined;
+  }
+
+  return frame.fields.find((f) => f.type === type) as Field<T> | undefined;
+};
+
+export const buildFrameViews = (
+  series: Array<{ name?: string; refId?: string; fields: Array<Field> }>,
+  options: TreemapOptions
+): FrameView[] => {
+  return series
+    .map((frame) => {
+      const text = findFieldByTypeAndName<string>(frame, FieldType.string, options.textField);
+      const size = findFieldByTypeAndName<number>(frame, FieldType.number, options.sizeField);
+
+      // Color is optional unless explicitly configured.
+      const colorByFieldExplicit = normalize(options.colorByField).length > 0;
+      const color = colorByFieldExplicit
+        ? findFieldByTypeAndName<number>(frame, FieldType.number, options.colorByField)
+        : size ?? findFieldByTypeAndName<number>(frame, FieldType.number);
+
+      const groupBy = frame.fields.find((f) => fieldMatches(f, options.groupByField));
+
+      const labels =
+        options.labelFields
+          ?.map((name) => frame.fields.find((f) => fieldMatches(f, name)))
+          .filter((f): f is Field => Boolean(f)) ?? [];
+
+      return {
+        name: frame.name,
+        refId: frame.refId,
+        text,
+        size,
+        color,
+        groupBy,
+        labels,
+      } as FrameView;
+    })
+    .filter((frame) => frame.text && frame.size && frame.color);
+};

--- a/src/frameSelection.ts
+++ b/src/frameSelection.ts
@@ -23,7 +23,7 @@ export const fieldMatches = (field: Field, wanted?: string): boolean => {
 };
 
 export const findFieldByTypeAndName = <T = unknown>(
-  frame: { fields: Array<Field> },
+  frame: { fields: Field[] },
   type: FieldType,
   wanted?: string
 ): Field<T> | undefined => {
@@ -35,7 +35,7 @@ export const findFieldByTypeAndName = <T = unknown>(
 };
 
 export const buildFrameViews = (
-  series: Array<{ name?: string; refId?: string; fields: Array<Field> }>,
+  series: Array<{ name?: string; refId?: string; fields: Field[] }>,
   options: TreemapOptions
 ): FrameView[] => {
   return series

--- a/src/grafana-plugin-support/src/components/FieldSelectEditor.tsx
+++ b/src/grafana-plugin-support/src/components/FieldSelectEditor.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { StandardEditorProps, FieldType } from "@grafana/data";
-import { MultiSelect, Select } from "@grafana/ui";
+import { Combobox, MultiSelect } from "@grafana/ui";
 
 interface Settings {
   filterByType: FieldType[];
@@ -52,12 +52,12 @@ export const FieldSelectEditor: React.FC<Props> = ({
       );
     } else {
       return (
-        <Select
-          isClearable
-          isLoading={false}
+        <Combobox<string>
+          isClearable={true}
+          loading={false}
           value={value as string | null}
           onChange={(e) => {
-            onChange(e?.value);
+            onChange(e?.value ?? null);
           }}
           options={options}
         />
@@ -65,5 +65,5 @@ export const FieldSelectEditor: React.FC<Props> = ({
     }
   }
 
-  return <Select onChange={() => {}} disabled={true} />;
+  return <Combobox<string> options={[]} value={null} onChange={() => {}} disabled={true} loading={false} />;
 };

--- a/src/treemap.ts
+++ b/src/treemap.ts
@@ -42,9 +42,9 @@ export const buildHierarchy = (frames: FrameView[]): TreemapNode => {
   frames.forEach((frame) => {
     Array.from({ length: frame.text!.values.length })
       .map((_, i) => ({
-        label: frame.text!.values.get(i),
-        value: frame.size!.values.get(i),
-        group: frame.groupBy?.values.get(i),
+        label: frame.text!.values[i],
+        value: frame.size!.values[i],
+        group: frame.groupBy?.values[i],
         separator: frame.text!.config.custom.separator,
       }))
       .forEach(({ label, value, group, separator }, index) => {


### PR DESCRIPTION
This PR fixes a common “Configure your query…” failure mode where the treemap panel can’t find the configured label/size/color fields after Grafana transformations (e.g., when fields are renamed via display name). It makes field selection more robust by matching against both raw field names and display-name variants, and keeps color optional unless explicitly configured—so the panel can render as long as label + size are present in a single frame.

In addition, it includes small refactors and cleanup to improve testability and reduce deprecated API usage.

Key changes

Robust field matching:
Match configured fields by [field.name](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and display-name sources (e.g., [displayName](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [displayNameFromDS](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), state display name).
Build “frame views” more deterministically so required fields are detected within a single data frame.
UX behavior:
Color field is optional unless explicitly configured; defaults to using size/standard coloring when not set.
Refactor for testability:
Extracted frame selection/build logic into a pure helper and added table-driven unit tests to cover matching behavior and edge cases.
Deprecation/lint cleanup:
Replace deprecated vector access patterns with index access.
Migrate away from deprecated [theme.v1](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) usage.
Replace deprecated [Select](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [Combobox](vscode-file://vscode-app/c:/Users/Jo%C3%A3o/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the field selector editor.
How to test

Unit tests: yarn test:ci
Lint/typecheck: yarn lint and yarn typecheck
Manual (Grafana):
Add a query returning multiple fields and apply transforms (join/organize/rename).
Configure treemap label/size (and optionally color) and verify it renders even when the visible column names come from display-name metadata.
Notes

There may still be a tooling notice about TypeScript version compatibility with @typescript-eslint/* (doesn’t affect runtime behavior, but can be addressed separately if desired).