### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps=true
+ignore-scripts=true


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `ignore-scripts=true` to `.npmrc`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place